### PR TITLE
fix: add security requirements to swagger and document Auth requirements

### DIFF
--- a/AzureKeyVaultEmulator/Startup.cs
+++ b/AzureKeyVaultEmulator/Startup.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
@@ -33,7 +34,25 @@ namespace AzureKeyVaultEmulator
 
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new OpenApiInfo {Title = "Azure KeyVault Emulator", Version = "v1"});
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "Azure KeyVault Emulator", Version = "v1" });
+                c.AddSecurityDefinition("JWT", new OpenApiSecurityScheme
+                {
+                    Name = "Authorization",
+                    In = ParameterLocation.Header,
+                    Type = SecuritySchemeType.Http,
+                    Description = "JWT Authorization header using the Bearer scheme. Use 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE4OTAyMzkwMjIsImlzcyI6Imh0dHBzOi8vbG9jYWxob3N0OjUwMDEvIn0.bHLeGTRqjJrmIJbErE-1Azs724E5ibzvrIc-UQL6pws'",
+                    Scheme = JwtBearerDefaults.AuthenticationScheme,
+                });
+                c.AddSecurityRequirement(new OpenApiSecurityRequirement
+                {
+                    {
+                        new OpenApiSecurityScheme
+                        {
+                            Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "JWT" }
+                        },
+                        Array.Empty<string>()
+                    }
+                });
             });
 
             services.AddHttpContextAccessor();

--- a/README.md
+++ b/README.md
@@ -26,14 +26,29 @@ The [Basis Theory](https://basistheory.com/) Azure KeyVault Emulator to mock int
 - Get Secret
 - Get Secret by Version
 
-### Requirements
+## Requirements
 
-Azure's KeyClient requires HTTPS communication with a KeyVault instance.
+### HTTPS
+
+Azure KeyClient and SecretClient require HTTPS communication with a KeyVault instance.
 When accessing the emulator on `localhost`, configure a trusted TLS certificate with [dotnet dev-certs](https://docs.microsoft.com/en-us/dotnet/core/additional-tools/self-signed-certificates-guide#with-dotnet-dev-certs).
 
 For accessing the emulator with a hostname other than `localhost`, a self-signed certificate needs to be generated and trusted by the client. See [Adding to docker-compose](#adding-to-docker-compose) for further instructions.
 
-### Adding to docker-compose
+### AuthN/AuthZ
+
+Azure KeyClient and SecretClient use a [ChallengeBasedAuthenticationPolicy](https://github.com/Azure/azure-sdk-for-net/blob/b30fa6d0d402511fdf3270c5d1d9ae5dfa2a0340/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs#L64-L66)
+to determine the authentication scheme used by the server. In order for the KeyVault Emulator to work with the Azure SDK, the emulator requires JWT authentication in the `Authorization` header with `Bearer` prefix.
+KeyVault Emulator only validates the JWT is well-formed.
+
+```shell
+curl -X 'GET' \
+  'https://localhost:5551/secrets/foo' \
+  -H 'accept: application/json' \
+  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE4OTAyMzkwMjIsImlzcyI6Imh0dHBzOi8vbG9jYWxob3N0OjUwMDEvIn0.bHLeGTRqjJrmIJbErE-1Azs724E5ibzvrIc-UQL6pws'
+```
+
+## Adding to docker-compose
 
 For the Azure KeyVault Emulator to be accessible from other containers in the same compose file, a new OpenSSL certificate has to be generated:
 1. Replace `<emulator-hostname>` and run the following script to generate a new public/private keypair:


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds Swagger Security Definition and global Security Requirement to pass AuthN requirements in Swagger UI
- Fixes #70 
- Adds AuthN/Authz section to README 

<!-- Please describe in detail how maintainers can test your changes. -->
## Testing required outside of automated testing?

- [X] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

<img width="661" alt="image" src="https://user-images.githubusercontent.com/43392371/163188488-b2f32ee6-9eb9-4db8-98ad-31912ce51035.png">

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [X] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
