### PR TITLE
Set correct scope expected by SDK

### DIFF
--- a/AzureKeyVaultEmulator/Startup.cs
+++ b/AzureKeyVaultEmulator/Startup.cs
@@ -82,8 +82,10 @@ namespace AzureKeyVaultEmulator
                     {
                         OnChallenge = context =>
                         {
+                            var requestHostSplit = context.Request.Host.ToString().Split(".", 2);
+                            var scope = $"https://{requestHostSplit[^1]}/.default";
                             context.Response.Headers.Remove("WWW-Authenticate");
-                            context.Response.Headers["WWW-Authenticate"] = $"Bearer authorization=\"https://localhost:5001/foo/bar\", scope=\"foobar\", resource=\"https://vault.azure.net\"";
+                            context.Response.Headers["WWW-Authenticate"] = $"Bearer authorization=\"https://localhost:5001/foo/bar\", scope=\"{scope}\", resource=\"https://vault.azure.net\"";
                             return Task.CompletedTask;
                         }
                     };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - 5551:5551
       - 5550:5550
     volumes:
-      - $PWD/local-certs:/https
+      - $PWD/local-certs:/https:ro
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=https://+:5551

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS += --silent
 
 verify:
-	docker-compose pull && ./scripts/verify.sh
+	./scripts/verify.sh
 
 acceptance-test:
 	./scripts/acceptancetest.sh

--- a/scripts/checks/dockercheck.sh
+++ b/scripts/checks/dockercheck.sh
@@ -2,8 +2,7 @@
 
 echo "Checking Docker..."
 
-EXPECTED_DOCKER="(18|19|20)\.[0-9]+\.[0-9]*"
-DISPLAY_DOCKER_REGEX=$(sed -e 's|\\\([.+?*()]\)|\1|g' -e 's|[.+?]\*|*|g' <<<${EXPECTED_DOCKER})
+EXPECTED_DOCKER="^[1-9][0-9]+\.[0-9]+\.[0-9]*"
 version=$(docker version --format '{{.Client.Version}}' 2>&1)
 
 if [[ $version == *"docker.sock"* ]]; then
@@ -15,6 +14,6 @@ fi
 if [[ "$version" =~ $EXPECTED_DOCKER ]]; then
     echo "Docker is OK"
 else
-    echo "Please Install Docker $DISPLAY_DOCKER_REGEX via Docker Desktop; https://www.docker.com/products/docker-desktop"
+    echo "Please Install Docker via Docker Desktop; https://www.docker.com/products/docker-desktop"
     exit 1
 fi

--- a/scripts/checks/dockercomposecheck.sh
+++ b/scripts/checks/dockercomposecheck.sh
@@ -2,7 +2,7 @@
 
 echo "Checking Docker Compose..."
 
-EXPECTED_COMPOSE_REGEX=1\.[1,2][0-9]\.[0-9]+
+EXPECTED_COMPOSE_REGEX=^[1-9][0-9]*\.[0-9]+\.[0-9]+
 DISPLAY_COMPOSE_REGEX=$(sed -e 's|\\\([.+?*()]\)|\1|g' -e 's|[.+?]\*|*|g' <<<${EXPECTED_COMPOSE_REGEX})
 
 version=$(docker-compose version --short 2>&1)


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description
Change the scope in the authentication challenge to match the (Python) SDK requirements.

The scope should be on the form `https://vault.azure.net/.default`. More info on scopes [Here](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc).

[Here](https://github.com/Azure/azure-sdk-for-python/blob/azure-keyvault-secrets_4.8.0/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py#L107-L126) is the code in the python SDK that requires this:
![bilde](https://github.com/Basis-Theory/azure-keyvault-emulator/assets/138445089/7af4b7e6-6117-421d-9d4a-ed05830107a0)
The scope is parsed as a url on line 116, and it is compared against the request URL on line 121.

-

<!-- Please describe in detail how maintainers can test your changes. -->
## Testing required outside of automated testing?
Here is a small test example using the azure.keyvaylt.secrets library:
```python
from azure.core.credentials import AccessToken, TokenCredential
from azure.keyvault.secrets import SecretClient


class LocalCredential(TokenCredential):
    def get_token(self, *args, **kwargs) -> AccessToken:
        return AccessToken("eyJhbGciOiJub25lIn0.eyJzdWIiOiIxIn0.", 9223372036854775807)


s = SecretClient("https://localhost.vault.azure.net:5551", LocalCredential())

print(s.get_secret("foo").value)
```

Previously it would give me the error
> The challenge contains invalid scope 'foobar'.

- [ ] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [ ] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
